### PR TITLE
Add CMake build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.lib
 *.exe
 *~
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,3 +20,10 @@ install(
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+
+# Generate pkg-config file
+configure_file(sexpresso.pc.in sexpresso.pc @ONLY)
+install(
+    FILES ${CMAKE_BINARY_DIR}/sexpresso.pc
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.0)
+
+# Define project
+project(sexpresso VERSION 1.0.0 DESCRIPTION "A C++ centric s-expression parser library.")
+
+# Shared library specification
+add_library(sexpresso SHARED sexpresso/sexpresso.cpp)
+
+# Set up version
+set_target_properties(sexpresso PROPERTIES VERSION ${PROJECT_VERSION})
+set_target_properties(sexpresso PROPERTIES SOVERSION 1)
+
+# Set up headers (public API)
+set_target_properties(sexpresso PROPERTIES PUBLIC_HEADER sexpresso/sexpresso.hpp)
+
+# Install rule
+include(GNUInstallDirs)
+install(
+    TARGETS sexpresso
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/README.org
+++ b/README.org
@@ -33,6 +33,16 @@ more unclearness of what includes what (since it ends up being a big chain), you
 
 After that you can move onward!
 
+** Building with CMake
+
+The project can be installed as a shared library using CMake:
+
+#+BEGIN_SRC sh
+mkdir build && cd build
+cmake ..
+make && make install
+#+END_SRC
+
 ** Parsing
 
 #+BEGIN_SRC c++

--- a/sexpresso.pc.in
+++ b/sexpresso.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+
+Requires:
+Libs: -L${libdir} -lsexpresso
+Cflags: -I${includedir}


### PR DESCRIPTION
Hi, thanks for your library! I help out with the LibrePCB project (https://github.com/librepcb/librepcb) which is using your library for serializing and parsing library elements.

Right now we link statically against your library (using a qmake config added [here in a fork](https://github.com/LibrePCB/sexpresso/tree/librepcb-patches)), but slowly distro maintainers are starting to package LibrePCB. And distro maintainers don't like statically linked libraries :slightly_smiling_face:

So I started thinking about packaging your library for Arch Linux, in order for LibrePCB to be able to link dynamically against it. However, without a build system this is a bit tricky. So here's a CMake configuration that allows building and installing your library easily.

Note: I don't really have much experience with CMake so far, I based the configuration on [this SO answer](https://stackoverflow.com/a/45843676/284318) which seems pretty nice. I picked CMake because it is widely used and pretty simple to use when packaging projects into Linux distros.

Note 2: The setup also generates a pkg-config file. This is very useful to be able to consume the library. For example, in qmake (which is used a lot in Qt projects), I could simply link against sexpresso by using `PKGCONFIG += sexpresso`, without having to set up include paths myself.

CC @ubruhin