### PR TITLE
Eliminate wall wextra warnings

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,0 +1,4 @@
+Sexpresso is available in the public domain through the CC0 license (see COPYING.txt for details, or https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+The following people have made contributions to sexpresso and consented to dedicating their changes to the public domain:
+
+Kenji Brameld, 2021

--- a/README.org
+++ b/README.org
@@ -206,5 +206,11 @@ auto joe = objs.getChildByPath("my-objects/object-b/name");
 ** Why should I use s-expressions
 because they are more elegant and simple than XML or JSON. Much less work required to parse. And they look nice! (subjective)
 
+* Contributing
+This library is public domain (CC0). Gnerally speaking by default, you have copyright on anything you make.
+So you have to explicitly give up copyrights in order to put something in the public domain.
+In this repository, please add your signature to [[CONTRIBUTORS.txt]] when contributing.
+
+
 * Future direction
 Make it a header-only library instead perhaps?

--- a/sexpresso/sexpresso.cpp
+++ b/sexpresso/sexpresso.cpp
@@ -235,7 +235,7 @@ namespace sexpresso {
 	static auto childrenEqual(std::vector<Sexp> const& a, std::vector<Sexp> const& b) -> bool {
 		if(a.size() != b.size()) return false;
 
-		for(unsigned i = 0; i < a.size(); ++i) {
+		for(auto i = 0u; i < a.size(); ++i) {
 			if(!a[i].equal(b[i])) return false;
 		}
 		return true;

--- a/sexpresso/sexpresso.cpp
+++ b/sexpresso/sexpresso.cpp
@@ -267,7 +267,6 @@ namespace sexpresso {
 		for(auto iter = nextiter; iter != str.end(); iter = nextiter) {
 			nextiter = iter + 1;
 			if(std::isspace(*iter)) continue;
-			auto& cursexp = sexprstack.top();
 			switch(*iter) {
 			case '(':
 				sexprstack.push(Sexp{});

--- a/sexpresso/sexpresso.cpp
+++ b/sexpresso/sexpresso.cpp
@@ -69,7 +69,7 @@ namespace sexpresso {
 			}
 		}
 		paths.push_back(std::string{start, path.end()});
-		return std::move(paths);
+		return paths;
 	}
 
 	auto Sexp::getChildByPath(std::string const& path) -> Sexp* {
@@ -257,7 +257,7 @@ namespace sexpresso {
 		auto s = Sexp{};
 		s.kind = SexpValueKind::STRING;
 		s.value.str = std::move(strval);
-		return std::move(s);
+		return s;
 	}
 
 	auto parse(std::string const& str, std::string& err) -> Sexp {
@@ -360,7 +360,7 @@ namespace sexpresso {
 				result_str.push_back(escape_chars[loc - escape_vals.begin()]);
 			}
 		}
-		return std::move(result_str);
+		return result_str;
 	}
 
 	SexpArgumentIterator::SexpArgumentIterator(Sexp& sexp) : sexp(sexp) {}

--- a/sexpresso/sexpresso.cpp
+++ b/sexpresso/sexpresso.cpp
@@ -121,6 +121,7 @@ namespace sexpresso {
 				case SexpValueKind::STRING:
 					return hd.getString() == name;
 				}
+				break;
 			}
 			case SexpValueKind::STRING:
 				return s.getString() == name;

--- a/sexpresso/sexpresso.cpp
+++ b/sexpresso/sexpresso.cpp
@@ -56,6 +56,7 @@ namespace sexpresso {
 		case SexpValueKind::STRING:
 			return 1;
 		}
+		return 0;
 	}
 
 	static auto splitPathString(std::string const& path) -> std::vector<std::string> {
@@ -124,6 +125,7 @@ namespace sexpresso {
 			case SexpValueKind::STRING:
 				return s.getString() == name;
 			}
+			return false;
 		};
 		auto loc = std::find_if(sexp.value.sexp.begin(), sexp.value.sexp.end(), findPred);
 		if(loc == sexp.value.sexp.end()) return nullptr;
@@ -247,6 +249,7 @@ namespace sexpresso {
 		case SexpValueKind::STRING:
 			return this->value.str == other.value.str;
 		}
+		return false;
 	}
 
 	auto Sexp::arguments() -> SexpArgumentIterator {

--- a/sexpresso/sexpresso.cpp
+++ b/sexpresso/sexpresso.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <sstream>
 #include <array>
+#include <iostream>
 
 namespace sexpresso {
 	Sexp::Sexp() {
@@ -56,6 +57,7 @@ namespace sexpresso {
 		case SexpValueKind::STRING:
 			return 1;
 		}
+		printShouldNeverReachHere();
 		return 0;
 	}
 
@@ -126,6 +128,7 @@ namespace sexpresso {
 			case SexpValueKind::STRING:
 				return s.getString() == name;
 			}
+			printShouldNeverReachHere();
 			return false;
 		};
 		auto loc = std::find_if(sexp.value.sexp.begin(), sexp.value.sexp.end(), findPred);
@@ -250,6 +253,7 @@ namespace sexpresso {
 		case SexpValueKind::STRING:
 			return this->value.str == other.value.str;
 		}
+		printShouldNeverReachHere();
 		return false;
 	}
 
@@ -364,6 +368,10 @@ namespace sexpresso {
 			}
 		}
 		return result_str;
+	}
+
+	auto printShouldNeverReachHere() -> void {
+		std::cerr << "Error: Should never reach here " << __FILE__ << ": " << __LINE__ << std::endl;
 	}
 
 	SexpArgumentIterator::SexpArgumentIterator(Sexp& sexp) : sexp(sexp) {}

--- a/sexpresso/sexpresso.cpp
+++ b/sexpresso/sexpresso.cpp
@@ -232,7 +232,7 @@ namespace sexpresso {
 	static auto childrenEqual(std::vector<Sexp> const& a, std::vector<Sexp> const& b) -> bool {
 		if(a.size() != b.size()) return false;
 
-		for(auto i = 0; i < a.size(); ++i) {
+		for(unsigned i = 0; i < a.size(); ++i) {
 			if(!a[i].equal(b[i])) return false;
 		}
 		return true;

--- a/sexpresso/sexpresso.hpp
+++ b/sexpresso/sexpresso.hpp
@@ -44,6 +44,7 @@ namespace sexpresso {
 	auto parse(std::string const& str, std::string& err) -> Sexp;
 	auto parse(std::string const& str) -> Sexp;
 	auto escape(std::string const& str) -> std::string;
+	auto printShouldNeverReachHere() -> void;
 
 	struct SexpArgumentIterator {
 		SexpArgumentIterator(Sexp& sexp);


### PR DESCRIPTION
Hi, thanks for the development of this library!
It has been proving useful in the development of a ROS project [Nao Soccer Sim](https://github.com/ijnek/naosoccer_sim).
I have eliminated all warnings when compiled with -Wall -Wextra for my project, and thought it may be useful for others also.

I have committed "per warning", so you can see exactly which changes were required against which warnings.